### PR TITLE
TTC 3.0.1 — Fix Fence selling reward crates & Kolya buy items

### DIFF
--- a/config/trader/kolya_base.json
+++ b/config/trader/kolya_base.json
@@ -6,7 +6,7 @@
   "balance_rub": 5000000,
   "balance_dol": 0,
   "balance_eur": 0,
-  "buyer_up": false,
+  "buyer_up": true,
   "currency": "RUB",
   "customization_seller": false,
   "discount": 0,

--- a/csharp/TTC.Mod/Load/PostDb.cs
+++ b/csharp/TTC.Mod/Load/PostDb.cs
@@ -217,6 +217,9 @@ public sealed class PostDb : IOnLoad
 				else if (cratesCreated > 0 && verbose)
 					_logger.Info($"[TTC][RewardCrates] Created {cratesCreated} reward crate templates");
 
+				// Blacklist reward crate IDs from Fence (created after initial Fence purge)
+				_fenceService.BlacklistAdditionalIds(_rewardCrateRegistry.AllCrateTemplateIds);
+
 				// Add Kolya to ragfair traders whitelist and generate his flea offers
 				_ragfairConfigurator.AddKolyaToRagfairTraders();
 				try

--- a/csharp/TTC.Mod/Services/Traders/FenceService.cs
+++ b/csharp/TTC.Mod/Services/Traders/FenceService.cs
@@ -29,6 +29,37 @@ public sealed class FenceService
     /// </summary>
     public void PurgeTtcAndUpdateBlacklist()
     {
+        // Collect ALL TTC item IDs: cards + binders + containers + mega items
+        var allTtcIds = new HashSet<string>(_state.Cards.Select(c => c.id));
+
+        if (_state.Binders != null)
+            foreach (var b in _state.Binders)
+                allTtcIds.Add(b.id);
+
+        if (_state.EmptyBooster != null)
+            allTtcIds.Add(_state.EmptyBooster.id);
+
+        if (_state.MegaBinder != null)
+            allTtcIds.Add(_state.MegaBinder.id);
+
+        if (_state.MegaBooster != null)
+            allTtcIds.Add(_state.MegaBooster.id);
+
+        PurgeAndBlacklist(allTtcIds);
+    }
+
+    /// <summary>
+    /// Add additional template IDs to the Fence blacklist (e.g. reward crate IDs created after initial purge).
+    /// </summary>
+    public void BlacklistAdditionalIds(IEnumerable<string> templateIds)
+    {
+        PurgeAndBlacklist(new HashSet<string>(templateIds));
+    }
+
+    private void PurgeAndBlacklist(HashSet<string> idsToBlock)
+    {
+        if (idsToBlock.Count == 0) return;
+
         try
         {
             // Purge current assort of TTC items
@@ -37,8 +68,7 @@ public sealed class FenceService
             var fenceId = "579dc571d53a0658a154fbec";
             if (traders != null && traders.TryGetValue(fenceId, out var fence) && fence?.Assort != null)
             {
-                var ttcTpls = new HashSet<MongoId>(_state.Cards.Select(c => new MongoId(c.id)));
-                var before = fence.Assort.Items?.Count ?? 0;
+                var ttcTpls = new HashSet<MongoId>(idsToBlock.Select(id => new MongoId(id)));
                 var removedAssortIds = new HashSet<MongoId>();
 
                 if (fence.Assort.Items != null)
@@ -60,11 +90,9 @@ public sealed class FenceService
                         fence.Assort.LoyalLevelItems?.Remove(rid);
                     }
                 }
-
-                var after = fence.Assort.Items?.Count ?? 0;
             }
 
-            // Update trader config fence blacklist set (typed)
+            // Update trader config fence blacklist set
             TraderConfig? traderCfg = null;
             try { traderCfg = _configServer.GetConfigByString<TraderConfig>("trader"); } catch { }
             if (traderCfg == null) { try { traderCfg = _configServer.GetConfigByString<TraderConfig>("spt-trader"); } catch { } }
@@ -78,11 +106,11 @@ public sealed class FenceService
                 {
                     if (fenceCfg.Blacklist is ISet<MongoId> setMi)
                     {
-                        foreach (var tpl in _state.Cards.Select(c => c.id)) _ = setMi.Add(new MongoId(tpl));
+                        foreach (var id in idsToBlock) _ = setMi.Add(new MongoId(id));
                     }
                     else if (fenceCfg.Blacklist is ISet<string> setStr)
                     {
-                        foreach (var tpl in _state.Cards.Select(c => c.id)) _ = setStr.Add(tpl);
+                        foreach (var id in idsToBlock) _ = setStr.Add(id);
                     }
                 }
                 catch { }

--- a/csharp/TTC.Mod/Services/Traders/KolyaRegistrationService.cs
+++ b/csharp/TTC.Mod/Services/Traders/KolyaRegistrationService.cs
@@ -61,7 +61,7 @@ public sealed class KolyaRegistrationService
                 UnlockedByDefault = true,
                 Medic = false,
                 CustomizationSeller = false,
-                BuyerUp = false,
+                BuyerUp = true,
                 Discount = 0,
                 DiscountEnd = 0,
                 BalanceRub = 5000000,
@@ -89,7 +89,7 @@ public sealed class KolyaRegistrationService
                 },
                 ItemsBuy = new ItemBuyData
                 {
-                    Category = new HashSet<MongoId> { new MongoId("5b47574386f77428ca22b2f1") },
+                    Category = new HashSet<MongoId> { new MongoId("54009119af1c881c07000029") }, // Item (root class — accepts everything)
                     IdList = new HashSet<MongoId>()
                 },
                 ItemsBuyProhibited = new ItemBuyData
@@ -101,9 +101,9 @@ public sealed class KolyaRegistrationService
                 LoyaltyLevels = new List<TraderLoyaltyLevel>
                 {
                     new() { BuyPriceCoefficient = 60, MinLevel = 1, MinSalesSum = 0, MinStanding = 0 },
-                    new() { BuyPriceCoefficient = 55, MinLevel = 1, MinSalesSum = 0, MinStanding = 0.20 },
-                    new() { BuyPriceCoefficient = 50, MinLevel = 1, MinSalesSum = 0, MinStanding = 0.40 },
-                    new() { BuyPriceCoefficient = 45, MinLevel = 1, MinSalesSum = 0, MinStanding = 0.60 }
+                    new() { BuyPriceCoefficient = 55, MinLevel = 1, MinSalesSum = 0, MinStanding = 1.80 },
+                    new() { BuyPriceCoefficient = 50, MinLevel = 1, MinSalesSum = 0, MinStanding = 4.00 },
+                    new() { BuyPriceCoefficient = 45, MinLevel = 1, MinSalesSum = 0, MinStanding = 6.50 }
                 }
             };
 


### PR DESCRIPTION
## Summary

Hotfix for two bugs reported after the 3.0.0 release.

### Bug Fixes

- **Fence selling reward crates for 1,300₽** — FenceService only blacklisted card IDs, not binders, boosters, mega items, or reward crates. Fence could sell THICC cases, holodilniks, and other reward packages for almost nothing. Now ALL TTC items are blacklisted from Fence, including reward crate template IDs (blacklisted in a second pass after crate creation).

- **Players can't sell cards to Kolya** — Two issues: `BuyerUp` was set to `false` in the C# trader clone (preventing all purchases), and `ItemsBuy.Category` used a handbook category ID instead of an item template parent class. Fixed by setting `BuyerUp = true` and using the root Item class so Kolya accepts everything.

- **Kolya loyalty levels not applied** — Loyalty level standings were hardcoded in `KolyaRegistrationService.cs` with old values (0.20/0.40/0.60) instead of the new thresholds (1.80/4.00/6.50). The JSON config `kolya_base.json` was never read by the C# code. Fixed by syncing the C# values.