### PR TITLE
TTC 3.0.3 — Fix survive & extract quest conditions

### DIFF
--- a/csharp/TTC.Client/TTC.Client.csproj
+++ b/csharp/TTC.Client/TTC.Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net471</TargetFramework>
     <AssemblyName>TTC</AssemblyName>
-    <Version>3.0.0</Version>
+    <Version>3.0.2</Version>
     <LangVersion>latest</LangVersion>
     <GameRoot>C:\Games\SPT-4.0</GameRoot>
   </PropertyGroup>

--- a/csharp/TTC.Client/TTC.Client.csproj
+++ b/csharp/TTC.Client/TTC.Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net471</TargetFramework>
     <AssemblyName>TTC</AssemblyName>
-    <Version>3.0.2</Version>
+    <Version>3.0.3</Version>
     <LangVersion>latest</LangVersion>
     <GameRoot>C:\Games\SPT-4.0</GameRoot>
   </PropertyGroup>

--- a/csharp/TTC.Mod/Services/Quests/QuestFactory.cs
+++ b/csharp/TTC.Mod/Services/Quests/QuestFactory.cs
@@ -20,6 +20,12 @@ namespace TTC.Mod.Services.Quests;
 public sealed class QuestFactory
 {
 	private static readonly string RoubleTpl = "5449016a4bdc2d6f028b456f";
+	private static readonly List<string> AllMapIds = new()
+	{
+		"bigmap", "factory4_day", "factory4_night", "Interchange", "Woods",
+		"Shoreline", "RezervBase", "TarkovStreets", "Lighthouse", "laboratory",
+		"Sandbox", "Sandbox_high"
+	};
 	private static readonly string[] AllLocaleCodes = { "ch", "cz", "en", "es-mx", "es", "fr", "ge", "hu", "it", "jp", "kr", "pl", "po", "ro", "ru", "sk", "tu" };
 
 	/// <summary>Replicate locale entries across all supported languages (English text as fallback).</summary>
@@ -212,8 +218,15 @@ public sealed class QuestFactory
 		}
 
 		// Objectives (CounterCreator conditions)
-		foreach (var obj in def.Objectives)
+		foreach (var rawObj in def.Objectives)
 		{
+			// Auto-fill SurviveLocations for "Survive" conditions without explicit maps
+			var obj = rawObj;
+			if (obj.ConditionType == "Survive" && obj.SurviveLocations == null)
+			{
+				obj = obj with { SurviveLocations = AllMapIds };
+			}
+
 			var condId = QuestIds.ConditionId(def.Seed, condIdx++);
 
 			if (obj.HealthEffectType != null)

--- a/csharp/TTC.Mod/TTC.Mod.csproj
+++ b/csharp/TTC.Mod/TTC.Mod.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
     <AssemblyName>TTC.Mod</AssemblyName>
-    <Version>3.0.2</Version>
+    <Version>3.0.3</Version>
     <RootNamespace>TTC.Mod</RootNamespace>
   </PropertyGroup>
 

--- a/csharp/TTC.Mod/TTC.Mod.csproj
+++ b/csharp/TTC.Mod/TTC.Mod.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
     <AssemblyName>TTC.Mod</AssemblyName>
-    <Version>3.0.0</Version>
+    <Version>3.0.2</Version>
     <RootNamespace>TTC.Mod</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
## 🔧 TTC 3.0.3 — Hotfix

### Fix

- **"Survive and extract" quest conditions were not tracking** — Objectives like "Survive and extract 3 times" never progressed, no matter how many raids you completed. Now works correctly on all maps. Just update and restart the server.