### PR TITLE
TTC 3.0.6 — Scav card loot config

### DIFF
--- a/config/mod_config.jsonc
+++ b/config/mod_config.jsonc
@@ -31,6 +31,10 @@
      spawn with cards like any other loot item. */
   "blacklist_cards_from_pmc_loot": true,
 
+  /* When true, TTC cards are injected into scav bot loot pools (pockets, vests, backpacks).
+     When false, scavs won't carry any cards. */
+  "enable_cards_in_scav_loot": true,
+
    // ─────────────────────────────────────────────
    // FINDING CARDS IN CONTAINERS
    // ─────────────────────────────────────────────

--- a/csharp/TTC.Client/TTC.Client.csproj
+++ b/csharp/TTC.Client/TTC.Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net471</TargetFramework>
     <AssemblyName>TTC</AssemblyName>
-    <Version>3.0.5</Version>
+    <Version>3.0.6</Version>
     <LangVersion>latest</LangVersion>
     <GameRoot>C:\Games\SPT-4.0</GameRoot>
   </PropertyGroup>

--- a/csharp/TTC.Mod/Load/PostDb.cs
+++ b/csharp/TTC.Mod/Load/PostDb.cs
@@ -253,6 +253,7 @@ public sealed class PostDb : IOnLoad
 		}
 
 		// Inject TTC cards into scav bot loot pools
+		if (_state.Config.enable_cards_in_scav_loot)
 		{
 			var scavAdded = _botLootCleanup.InjectCardsIntoScavLoot();
 			if (verbose && scavAdded > 0)

--- a/csharp/TTC.Mod/Mod/TTCModMetadata.cs
+++ b/csharp/TTC.Mod/Mod/TTCModMetadata.cs
@@ -11,7 +11,7 @@ public sealed record TTCModMetadata : AbstractModMetadata
     public override string Name { get; init; } = "TarkovTradingCards";
     public override string Author { get; init; } = "Chazut";
     public override List<string>? Contributors { get; init; } = null;
-    public override SemVerVersion Version { get; init; } = new("3.0.0");
+    public override SemVerVersion Version { get; init; } = new("3.0.6");
     public override SemVerRange SptVersion { get; init; } = new("~4.0.0");
     public override List<string>? Incompatibilities { get; init; } = null;
     public override Dictionary<string, SemVerRange>? ModDependencies { get; init; } = null;

--- a/csharp/TTC.Mod/Models/ModConfig.cs
+++ b/csharp/TTC.Mod/Models/ModConfig.cs
@@ -19,4 +19,5 @@ public record ModConfig
     public bool enable_quests { get; init; } = true;
     public bool unlock_all_barters { get; init; } = false;
     public bool blacklist_cards_from_pmc_loot { get; init; } = true;
+    public bool enable_cards_in_scav_loot { get; init; } = true;
 }

--- a/csharp/TTC.Mod/TTC.Mod.csproj
+++ b/csharp/TTC.Mod/TTC.Mod.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
     <AssemblyName>TTC.Mod</AssemblyName>
-    <Version>3.0.5</Version>
+    <Version>3.0.6</Version>
     <RootNamespace>TTC.Mod</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

- Add `enable_cards_in_scav_loot` config option (default `true`). Set to `false` to disable card injection into scav bot loot pools.