### PR TITLE
🔧 TTC 3.0.8 — Hotfix

### DIFF
--- a/config/quests_extended/TTC_quests.json
+++ b/config/quests_extended/TTC_quests.json
@@ -1371,7 +1371,7 @@
     "Conditions": [
       {
         "ConditionId": "7ec011a509070ee401ddfe75",
-        "ConditionType": "DamageWithGrenades"
+        "ConditionType": "DamageWithThrowables"
       },
       {
         "ConditionId": "76f4934c892c94b848a5d1bf",
@@ -1409,7 +1409,7 @@
     "Conditions": [
       {
         "ConditionId": "dc7cc4213a2497d01e96b0b6",
-        "ConditionType": "DamageWithGrenades"
+        "ConditionType": "DamageWithThrowables"
       },
       {
         "ConditionId": "04ff08192e0c39f61b1134a7",
@@ -1675,7 +1675,7 @@
     "Conditions": [
       {
         "ConditionId": "51bf7d4997ad83d35d24f407",
-        "ConditionType": "DamageWithGrenades"
+        "ConditionType": "DamageWithThrowables"
       }
     ]
   },
@@ -1925,7 +1925,7 @@
     "Conditions": [
       {
         "ConditionId": "61dcb60bb970a3fda1218e01",
-        "ConditionType": "DamageWithGrenades"
+        "ConditionType": "DamageWithThrowables"
       },
       {
         "ConditionId": "ba3247841e97b171094694ac",
@@ -1967,7 +1967,7 @@
     "Conditions": [
       {
         "ConditionId": "844e521f53876d1bfeaddab2",
-        "ConditionType": "DamageWithGrenades"
+        "ConditionType": "DamageWithThrowables"
       },
       {
         "ConditionId": "507c3d644c4001a6c7d48589",
@@ -2371,7 +2371,7 @@
     "Conditions": [
       {
         "ConditionId": "e85d80d74a9513a57a9f1a44",
-        "ConditionType": "DamageWithGrenades"
+        "ConditionType": "DamageWithThrowables"
       }
     ]
   },

--- a/csharp/TTC.Client/TTC.Client.csproj
+++ b/csharp/TTC.Client/TTC.Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net471</TargetFramework>
     <AssemblyName>TTC</AssemblyName>
-    <Version>3.0.7</Version>
+    <Version>3.0.8</Version>
     <LangVersion>latest</LangVersion>
     <GameRoot>C:\Games\SPT-4.0</GameRoot>
   </PropertyGroup>

--- a/csharp/TTC.Mod/Mod/TTCModMetadata.cs
+++ b/csharp/TTC.Mod/Mod/TTCModMetadata.cs
@@ -11,7 +11,7 @@ public sealed record TTCModMetadata : AbstractModMetadata
     public override string Name { get; init; } = "TarkovTradingCards";
     public override string Author { get; init; } = "Chazut";
     public override List<string>? Contributors { get; init; } = null;
-    public override SemVerVersion Version { get; init; } = new("3.0.7");
+    public override SemVerVersion Version { get; init; } = new("3.0.8");
     public override SemVerRange SptVersion { get; init; } = new("~4.0.0");
     public override List<string>? Incompatibilities { get; init; } = null;
     public override Dictionary<string, SemVerRange>? ModDependencies { get; init; } = null;

--- a/csharp/TTC.Mod/Services/Containers/RewardCrateFactory.cs
+++ b/csharp/TTC.Mod/Services/Containers/RewardCrateFactory.cs
@@ -123,7 +123,7 @@ public sealed class RewardCrateFactory
 					RandomRewardType.RandomMeds => 50000,
 					RandomRewardType.RandomKeys => 100000,
 					RandomRewardType.BoosterPack => 200000,
-					_ => 10000
+					_ => 5000000 // Fixed reward crates (collection rewards, multi-item barters) — high value prevents scav case from rolling them
 				},
 				FleaPriceRoubles = null
 			};

--- a/csharp/TTC.Mod/Services/Quests/BuggedRealityThemeDefinitions.cs
+++ b/csharp/TTC.Mod/Services/Quests/BuggedRealityThemeDefinitions.cs
@@ -189,7 +189,7 @@ public static class BuggedRealityThemeDefinitions
 				PrerequisiteSeed = "ttc_quest_card_bugd_doorpeeker",
 				Objectives = new()
 				{
-					new() { ConditionType = "DamageWithGrenades", Value = 1000, Description = "Deal 1,000 damage with grenades" },
+					new() { ConditionType = "DamageWithThrowables", Value = 1000, Description = "Deal 1,000 damage with grenades" },
 					new() { ConditionType = "FixLightBleed", Value = 5, Description = "Fix 5 light bleeds" }
 				},
 				Locale = new()
@@ -269,7 +269,7 @@ public static class BuggedRealityThemeDefinitions
 				PrerequisiteSeed = "ttc_quest_card_bugd_adslock",
 				Objectives = new()
 				{
-					new() { ConditionType = "DamageWithGrenades", Value = 5000, Description = "Deal 5,000 damage with grenades" },
+					new() { ConditionType = "DamageWithThrowables", Value = 5000, Description = "Deal 5,000 damage with grenades" },
 					new() { ConditionType = "FixHeavyBleed", Value = 10, Description = "Fix 10 heavy bleeds" }
 				},
 				Locale = new()

--- a/csharp/TTC.Mod/Services/Quests/QuestFactory.cs
+++ b/csharp/TTC.Mod/Services/Quests/QuestFactory.cs
@@ -681,7 +681,7 @@ public sealed class QuestFactory
 		// Damage-related
 		"DamageWithAR" or "DamageWithDMR" or "DamageWithLMG" or "DamageWithPistols"
 			or "DamageWithRevolvers" or "DamageWithShotguns" or "DamageWithSMG" or "DamageWithAny"
-			or "DamageToArmour" or "DamageToArmourWithShotguns"
+			or "DamageWithThrowables" or "DamageToArmour" or "DamageToArmourWithShotguns"
 			or "TotalShotDistanceWithSnipers" or "DestroyLegsWithSMG" => "Elimination",
 		// Everything else
 		_ => "Completion"

--- a/csharp/TTC.Mod/Services/Quests/SeasonalEventsThemeDefinitions.cs
+++ b/csharp/TTC.Mod/Services/Quests/SeasonalEventsThemeDefinitions.cs
@@ -140,7 +140,7 @@ public static class SeasonalEventsThemeDefinitions
 				PrerequisiteSeed = "ttc_quest_card_seas_goldengun",
 				Objectives = new()
 				{
-					new() { ConditionType = "DamageWithGrenades", Value = 500, Description = "Deal 500 damage with grenades" },
+					new() { ConditionType = "DamageWithThrowables", Value = 500, Description = "Deal 500 damage with grenades" },
 					new() { ConditionType = "Kills", Value = 5, Description = "Eliminate 5 targets", KillTarget = "Any" }
 				},
 				Locale = new()

--- a/csharp/TTC.Mod/Services/Quests/StreamerMomentsThemeDefinitions.cs
+++ b/csharp/TTC.Mod/Services/Quests/StreamerMomentsThemeDefinitions.cs
@@ -397,7 +397,7 @@ public static class StreamerMomentsThemeDefinitions
 				PrerequisiteSeed = "ttc_quest_card_strm_dontpeek",
 				Objectives = new()
 				{
-					new() { ConditionType = "DamageWithGrenades", Value = 3000, Description = "Deal 3,000 damage with grenades" },
+					new() { ConditionType = "DamageWithThrowables", Value = 3000, Description = "Deal 3,000 damage with grenades" },
 					new() { ConditionType = "Kills", Value = 5, Description = "Eliminate 5 targets from under 15m", KillTarget = "Any", KillDistanceCompare = "<=", KillDistanceValue = 15 }
 				},
 				Locale = new()

--- a/csharp/TTC.Mod/Services/Quests/TarkovFailsThemeDefinitions.cs
+++ b/csharp/TTC.Mod/Services/Quests/TarkovFailsThemeDefinitions.cs
@@ -277,7 +277,7 @@ public static class TarkovFailsThemeDefinitions
 				PrerequisiteSeed = "ttc_quest_card_fail_wrongextract",
 				Objectives = new()
 				{
-					new() { ConditionType = "DamageWithGrenades", Value = 500, Description = "Deal 500 damage with grenades" },
+					new() { ConditionType = "DamageWithThrowables", Value = 500, Description = "Deal 500 damage with grenades" },
 					new() { ConditionType = "FixLightBleed", Value = 5, Description = "Fix 5 light bleeds" }
 				},
 				Locale = new()
@@ -357,7 +357,7 @@ public static class TarkovFailsThemeDefinitions
 				PrerequisiteSeed = "ttc_quest_card_fail_openheal",
 				Objectives = new()
 				{
-					new() { ConditionType = "DamageWithGrenades", Value = 2000, Description = "Deal 2,000 damage with grenades" },
+					new() { ConditionType = "DamageWithThrowables", Value = 2000, Description = "Deal 2,000 damage with grenades" },
 					new() { ConditionType = "FixHeavyBleed", Value = 5, Description = "Fix 5 heavy bleeds" }
 				},
 				Locale = new()

--- a/csharp/TTC.Mod/TTC.Mod.csproj
+++ b/csharp/TTC.Mod/TTC.Mod.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
     <AssemblyName>TTC.Mod</AssemblyName>
-    <Version>3.0.7</Version>
+    <Version>3.0.8</Version>
     <RootNamespace>TTC.Mod</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
### Fixes

- **"Deal X damage with grenades" quest objectives were not tracking** — The condition type was incorrect. Now works properly with all throwable explosives.

- **Fixed reward crates (collection rewards, multi-item barters) could appear as cheap scav case loot** — These crates now have a high handbook value (5M₽) preventing them from being rolled by the scav case generator.